### PR TITLE
Fix agreement signature field

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## Install
 
-You need a private key from @boklisten to use this module.
-
 ```text
 npm install @boklisten/bl-email
 ```

--- a/src/pages/receipt-with-agreement.html
+++ b/src/pages/receipt-with-agreement.html
@@ -16,6 +16,12 @@
         <div class="text-center bl-main-title">
           <b>{{i 'emailTemplateConfig.receipt-with-agreement.text.title'}}</b>
         </div>
+          <div class="bl-text-tiny bl-center-text bl-scale-down">
+            {{i 'emailTemplateConfig.partial.item-list.text.orderIdTitle'}}
+            {{{{raw}}}}
+              {{emailTemplateInput.order.id}}
+            {{{{/raw}}}}
+          </div>
       </columns>
     </row>
   </container>
@@ -145,8 +151,11 @@
       <columns>
         <div>____________________</div>
         <div class="bl-text-tiny bl-center-text bl-scale-down">
-          {{{{raw}}}} {{emailTemplateInput.creationTime}} -
-          {{emailTemplateInput.order.id}} {{{{/raw}}}}
+            {{i 'emailTemplateConfig.receipt-with-agreement.text.customerSignature'}}
+            <br/>
+          {{{{raw}}}}
+            {{emailTemplateInput.user.name}} - {{emailTemplateInput.creationTime}}
+          {{{{/raw}}}}
         </div>
       </columns>
       <columns>
@@ -182,8 +191,12 @@
       {{i 'emailTemplateConfig.general.contact.organizationNumber.value'}}
     </div>
     <div class="bl-text-tiny bl-center-text">
-      {{{{raw}}}} {{emailTemplateInput.creationTime}} -
-      {{emailTemplateInput.order.orderId}} {{{{/raw}}}}
+      {{emailTemplateInput.creationTime}} -
+      {{i 'emailTemplateConfig.partial.item-list.text.orderIdTitle'}}
+      {{{{raw}}}}
+        {{emailTemplateInput.order.id}}
+      {{{{/raw}}}}
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
The customer signature field description was previously "{date} - {orderID}". It has been changed to the more sensible "{field description} {customer name} - {date}". The order ID has been moved underneath the title, and also re-added at the very bottom.

Also removes the `NPM_TOKEN` env variable requirement.

https://trello.com/c/6iXbhaoq/